### PR TITLE
Seb

### DIFF
--- a/pyEPR/_config_default.py
+++ b/pyEPR/_config_default.py
@@ -35,6 +35,14 @@ config = Dict( # pylint: disable=invalid-name
         # 					Will calculate the Pj matrix for the selected modes for the given junctions
         # 					junc_rect array & length of junctions
         method_calc_P_mj='line_voltage',
+        
+        # method_calc_Q sets the method to calculate the external quality factors in eigenmode.
+        # Valid values :
+        #    'SurfaceLossDensity' : integrates the SurfaceLossDensity (i.e. real 
+        #                           part of the Poynting vector) over the surface
+        #    'Jsurf' : calculates the average value of the peak current across  
+        #              the resistor and deduces the dissipated Joule power.
+        method_calc_Q='SurfaceLossDensity',
 
         # To save or not the mesh statistics from an HFSS run
         save_mesh_stats=True,

--- a/pyEPR/_config_default.py
+++ b/pyEPR/_config_default.py
@@ -43,6 +43,12 @@ config = Dict( # pylint: disable=invalid-name
         #    'Jsurf' : calculates the average value of the peak current across  
         #              the resistor and deduces the dissipated Joule power.
         method_calc_Q='SurfaceLossDensity',
+        
+        # Sets whether U_H and / or U_E are used to calculate the mode energy.
+        # If both are False, you must be 100% sure that your simulation has converged well.
+        # Note that calculating U_H takes much more time than calculating U_E.
+        calc_U_H = False,
+        calc_U_E = True,
 
         # To save or not the mesh statistics from an HFSS run
         save_mesh_stats=True,
@@ -58,7 +64,7 @@ config = Dict( # pylint: disable=invalid-name
         # 2     : use enforcement of U_J_total to be U_mode-U_H (i.e., 1)
         #         only when the total particiaption is above a certain threshold
         #         preffered method.
-        renorm_pj = 2,
+        renorm_pj = False,
     ),
 
     # Loss properties of various materials and surfaces

--- a/pyEPR/_config_user.py
+++ b/pyEPR/_config_user.py
@@ -73,7 +73,14 @@ config = Dict( # pylint: disable=invalid-name
         # 					Will calculate the Pj matrix for the selected modes for the given junctions
         # 					junc_rect array & length of junctions
         method_calc_P_mj='line_voltage',
-
+        
+        # method_calc_Q sets the method to calculate the external quality factors in eigenmode.
+        # Valid values :
+        #    'SurfaceLossDensity' : integrates the SurfaceLossDensity (i.e. real 
+        #                           part of the Poynting vector) over the surface
+        #    'Jsurf' : calculates the average value of the peak current across  
+        #              the resistor and deduces the dissipated Joule power.
+        method_calc_Q='SurfaceLossDensity',
     ),
 
     plotting=Dict(

--- a/pyEPR/ansys.py
+++ b/pyEPR/ansys.py
@@ -1476,7 +1476,7 @@ class HfssEMDesignSolutions(HfssDesignSolutions):
             self._solutions.EditSources(
                 [
                     [
-                        "FieldType:=", "EigenPeakElectricField"
+                        "FieldType:=", FieldType
                     ],
                     [
                         "Name:=", "Modes",
@@ -1491,7 +1491,7 @@ class HfssEMDesignSolutions(HfssDesignSolutions):
             # see https://ansyshelp.ansys.com/account/secured?returnurl=/Views/Secured/Electronics/v195//Subsystems/HFSS/Subsystems/HFSS%20Scripting/HFSS%20Scripting.htm
 
             self._solutions.EditSources(
-                "EigenStoredEnergy",
+                FieldType,
                 ["NAME:SourceNames", "EigenMode"],
                 ["NAME:Modes", n_modes],
                 ["NAME:Magnitudes"] + [1 if i + 1 ==

--- a/pyEPR/core_distributed_analysis.py
+++ b/pyEPR/core_distributed_analysis.py
@@ -600,7 +600,7 @@ class DistributedAnalysis(object):
     def calc_energy_magnetic(self,
                              variation=None,
                              volume='AllObjects',
-                             smooth=True):
+                             smooth=False):
         '''
         See calc_energy_electric.
 

--- a/pyEPR/core_distributed_analysis.py
+++ b/pyEPR/core_distributed_analysis.py
@@ -1113,8 +1113,7 @@ class DistributedAnalysis(object):
                 def _parse(name): return ureg.Quantity(
                     _variables['_'+val[name]]).to_base_units().magnitude
                 Ljs[junc_name] = _parse('Lj_variable')
-                Cjs[junc_name] = 2E-15  # _parse(
-                # 'Cj_variable') if 'Cj_variable' in val else 0
+                Cjs[junc_name] = _parse('Cj_variable') if 'Cj_variable' in val else 0.0
 
         return Ljs, Cjs
 

--- a/pyEPR/core_distributed_analysis.py
+++ b/pyEPR/core_distributed_analysis.py
@@ -688,7 +688,7 @@ class DistributedAnalysis(object):
         uj = ConstantVecCalcObject(uj, self.setup)
         calc = CalcObject([], self.setup)
         #calc = calc.getQty("Jsurf").mag().integrate_surf(name = junc_rect)
-        calc = (((calc.getQty("Jsurf")).dot(uj)).imag()
+        calc = (((calc.getQty("Jsurf")).dot(uj)).complexmag()
                 ).integrate_surf(name=junc_rect)
         I = calc.evaluate(lv=lv) / jl  # phase = 90
         # self.design.Clear_Field_Clac_Stack()

--- a/pyEPR/core_distributed_analysis.py
+++ b/pyEPR/core_distributed_analysis.py
@@ -668,7 +668,7 @@ class DistributedAnalysis(object):
         Returns:
             Value of the dissipated power.
         '''
-        lv = self.get_lv(variation)
+        lv = self._get_lv(variation)
 
         calc = CalcObject([], self.setup)
         calc = (calc.getQty("SurfaceLossDensity")).integrate_surf(name=surf)
@@ -938,7 +938,7 @@ class DistributedAnalysis(object):
 
         return Qp
 
-    def calc_p_junction(self, variation, U_H, U_E, Ljs, Cjs):
+    def calc_p_junction(self, variation, U_H, U_E, Ljs, Cjs, mode):
         '''
         For a single specific mode.
         Expected that you have specified the mode before calling this, `self.set_mode(num)`
@@ -1010,18 +1010,10 @@ class DistributedAnalysis(object):
             V_peak_[j_name] = V_peak
             Sj['s_' + j_name] = _Smj = 1 if V_peak > 0 else - 1
 
-            # REPORT prelimnary
-            pmj_ind = 0.5*Ljs[j_name] * I_peak**2 / U_E
-            pmj_cap = 0.5*Cjs[j_name] * V_peak**2 / U_E
-            #print('\tpmj_ind=',pmj_ind, Ljs[j_name], U_E)
-
             self.I_peak = I_peak
             self.V_peak = V_peak
             self.Ljs = Ljs
             self.Cjs = Cjs
-            print(
-                f'\t{j_name:<15} {pmj_ind:>8.6g}{("(+)"if _Smj else "(-)"):>5s}        {pmj_cap:>8.6g}')
-            #print('\tV_peak=', V_peak)
 
         # ------------------------------------------------------------
         # Calcualte participations from the peak voltage and currents
@@ -1033,18 +1025,35 @@ class DistributedAnalysis(object):
         U_J_caps = {j_name: 0.5*Cjs[j_name] * V_peak_[j_name]
                     ** 2 for j_name in self.pinfo.junctions}
 
-        U_tot_ind = U_H + sum(list(U_J_inds.values()))  # total
-        U_tot_cap = U_E + sum(list(U_J_caps.values()))
+        if U_H == None and U_E == None:
+            print('''\tWARNING: neither U_H nor U_E were configured to be calculated. \
+                  It's fine only if you're sure the simulation has converged sufficiently \
+                  so that the modes energies are as defined in Edit Sources (ie 1 Joule)''')
+            U_tot_ind = 1.0
+            U_tot_cap = 1.0
+            U_norm    = 1.0
+        elif U_H == None:
+            print('\tUsing E field only to calculate the mode energy (faster but lacks sanity check).')
+            U_tot_cap = U_E + sum(list(U_J_caps.values()))
+            U_tot_ind = U_tot_cap
+            U_norm    = U_tot_cap
+        elif U_E == None:
+            print('\tUsing H field only to calculate the mode energy.')
+            U_tot_ind = U_H + sum(list(U_J_inds.values()))
+            U_tot_cap = U_tot_ind
+            U_norm    = U_tot_ind
+        else:
+            U_tot_ind = U_H + sum(list(U_J_inds.values()))
+            U_tot_cap = U_E + sum(list(U_J_caps.values()))
+            U_norm    = (U_tot_ind + U_tot_cap) / 2
 
-        # what to use for the norm?  U_tot_cap or the mean of  U_tot_ind and  U_tot_cap?
-        # i.e., (U_tot_ind + U_tot_cap)/2
-        U_norm = U_tot_cap
         U_diff = (U_tot_cap-U_tot_ind)/(U_tot_cap+U_tot_ind)
-        print("\t\t"f"(U_tot_cap-U_tot_ind)/mean={U_diff*100:.2f}%")
-        if abs(U_diff) > 0.15:
-            print('WARNING: This simulation must not have converged well!!!\
-                The difference in the total cap and ind energies is larger than 10%.\
-                Proceed with caution.')
+        if U_H != None and U_E != None:
+            print("\t\t"f"(U_tot_cap-U_tot_ind)/mean={U_diff*100:.2f}%")
+            if abs(U_diff) > 0.15:
+                print('WARNING: This simulation must not have converged well!!!\
+                    The difference in the total cap and ind energies is larger than 10%.\
+                    Proceed with caution.')
 
         Pj = pd.Series(OrderedDict([(j_name, Uj_ind/U_norm)
                                     for j_name, Uj_ind in U_J_inds.items()]))
@@ -1052,10 +1061,13 @@ class DistributedAnalysis(object):
         PCj = pd.Series(OrderedDict([(j_name, Uj_cap/U_norm)
                                      for j_name, Uj_cap in U_J_caps.items()]))
 
-        # print('\t{:<15} {:>8.6g} {:>5s}'.format(
-        #    j_name,
-        #    Pj['p_' + j_name],
-        #    '+' if Sj['s_' + j_name] > 0 else '-'))
+        print(f"\n\t{'junction':<15s} EPR p_{mode}j   sign s_{mode}j    (p_capacitive)")
+        for j_name, j_props in self.pinfo.junctions.items():
+            pmj_ind = Pj[j_name]
+            pmj_cap = PCj[j_name]
+            _Smj    = Sj['s_' + j_name]
+            print(
+                f'\t{j_name:<15} {pmj_ind:>8.6g}{("(+)"if _Smj else "(-)"):>5s}        {pmj_cap:>8.6g}')
 
         return Pj, Sj, PCj, pd.Series(I_peak), pd.Series(V_peak), \
             {'U_J_inds': U_J_inds,
@@ -1233,7 +1245,7 @@ class DistributedAnalysis(object):
             for mode in modes:  # integer of mode number [0,1,2,3,..]
 
                 # Load fields for mode
-                self.set_mode(mode)
+                self.set_mode(mode, FieldType='EigenStoredEnergy')
 
                 # Get HFSS  solved frequencies
                 _Om = pd.Series({})
@@ -1244,40 +1256,55 @@ class DistributedAnalysis(object):
                     '\n'f'  \033[1mMode {mode} at {"%.2f" % temp_freq} GHz   [{mode+1}/{self.n_modes}]\033[0m')
 
                 # EPR Hamiltonian calculations
-                # Calculation global energies and report
+                # Calculate global field energies  
+                # Report the peak energy - the 2 is from the calculation method
 
                 # Magnetic
-                print('    Calculating ℰ_magnetic', end=',')
-                try:
-                    self.U_H = self.calc_energy_magnetic(variation)
-                except Exception as e:
-                    tb = sys.exc_info()[2]
-                    print("\n\nError:\n", e)
-                    raise(Exception(' Did you save the field solutions?\n\
-                    Failed during calculation of the total magnetic energy.\
-                    This is the first calculation step, and is indicative that there are \
-                    no field solutions saved. ').with_traceback(tb))
+                if self.pinfo.options.calc_U_H == True:     
+                    print('    Calculating ℰ_magnetic:', end=' ')
+                    try:
+                        self.U_H = self.calc_energy_magnetic(variation)
+                    except Exception as e:
+                        tb = sys.exc_info()[2]
+                        print("\n\nError:\n", e)
+                        raise(Exception(' Did you save the field solutions?\n\
+                        Failed during calculation of the total magnetic energy.\
+                        This is the first calculation step, and is indicative that there are \
+                        no field solutions saved. ').with_traceback(tb))
+                    print(f"{self.U_H/2:>9.4g}")
+                else:
+                    self.U_H = None
 
                 # Electric
-                print('ℰ_electric')
-                self.U_E = self.calc_energy_electric(variation)
+                if self.pinfo.options.calc_U_E == True:
+                    print('    Calculating ℰ_electric:', end=' ')
+                    try:
+                        self.U_E = self.calc_energy_electric(variation)
+                    except Exception as e:
+                        tb = sys.exc_info()[2]
+                        print("\n\nError:\n", e)
+                        raise(Exception(' Did you save the field solutions?\n\
+                        Failed during calculation of the total magnetic energy.\
+                        This is the first calculation step, and is indicative that there are \
+                        no field solutions saved. ').with_traceback(tb))
+                    print(f"{self.U_E/2:>9.4g}")
+                else:
+                    self.U_E = None
+                    
+                if self.pinfo.options.calc_U_H == True and self.pinfo.options.calc_U_E == True:
+                    print(f"     (ℰ_E-ℰ_H)/ℰ_E = {100*(self.U_E - self.U_H)/self.U_E:.1f}")
 
                 # the unnormed
                 sol = pd.Series({'U_H': self.U_H, 'U_E': self.U_E})
 
-                # Fraction - report the peak energy, properly normalized
-                # the 2 is from the calcualtion methods
-                print(f"""     {'(ℰ_E-ℰ_H)/ℰ_E':>15s} {'ℰ_E':>9s} {'ℰ_H':>9s}
-    {100*(self.U_E - self.U_H)/self.U_E:>15.1f}%  {self.U_E/2:>9.4g} {self.U_H/2:>9.4g}\n""")
-
                 # Calcualte EPR for each of the junctions
                 print(
-                    f'    Calculating junction energy participation ration (EPR)\n\tmethod=`{self.pinfo.options.method_calc_P_mj}`. First estimates:')
-                print(
-                    f"\t{'junction':<15s} EPR p_{mode}j   sign s_{mode}j    (p_capacitive)")
+                    f'    Calculating junction energy participation ration (EPR)\n\tMethod=`{self.pinfo.options.method_calc_P_mj}`.')
 
+                half_U_H = self.U_H / 2.0 if self.U_H else None
+                half_U_E = self.U_E / 2.0 if self.U_E else None
                 Pm[mode], Sm[mode], Pm_cap[mode], I_peak[mode], V_peak[mode], ansys_energies[mode] = self.calc_p_junction(
-                    variation, self.U_H/2., self.U_E/2., Ljs, Cjs)
+                    variation, half_U_H, half_U_E, Ljs, Cjs, mode)
 
                 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
                 # EPR Dissipative calculations -- should be a function block below
@@ -1498,7 +1525,7 @@ class DistributedAnalysis(object):
         '''
         return self.hfss_report_f_convergence(variation)
 
-    def set_mode(self, mode_num, phase=0):
+    def set_mode(self, mode_num, phase=0, FieldType='EigenStoredEnergy'):
         '''
         Set source excitations should be used for fields post processing.
         Counting modes from 0 onward
@@ -1508,7 +1535,7 @@ class DistributedAnalysis(object):
         if mode_num < 0:
             logger.error('Too small a mode number')
 
-        self.solutions.set_mode(mode_num + 1, phase)
+        self.solutions.set_mode(mode_num + 1, phase, FieldType)
 
         if self.has_fields() == False:
             logger.warning(f" Error: HFSS does not have field solution for variation={mode_num}.\

--- a/pyEPR/core_distributed_analysis.py
+++ b/pyEPR/core_distributed_analysis.py
@@ -655,6 +655,26 @@ class DistributedAnalysis(object):
         ℰ_object = self.calc_energy_electric(volume=name_dielectric3D)
 
         return ℰ_object/ℰ_total, (ℰ_object, ℰ_total)
+    
+    def calc_surf_loss(self, variation, surf):
+        ''' Power dissipated in a lossy surface (e.g. lumped R).
+            Integrate the SurfaceLossDensity over the surface.
+            SurfaceLossDensity is an HFSS short hand for 
+            the real part of the Pyonting vector.
+        Args:
+            variation (str): A string identifier of the variation,
+                such as '0', '1', ...
+            surf (str) : name of the surface to integrate over.
+        Returns:
+            Value of the dissipated power.
+        '''
+        lv = self.get_lv(variation)
+
+        calc = CalcObject([], self.setup)
+        calc = (calc.getQty("SurfaceLossDensity")).integrate_surf(name=surf)
+        P = calc.evaluate(lv=lv)
+        
+        return P
 
     def calc_current(self, fields, line: str):
         '''
@@ -899,9 +919,18 @@ class DistributedAnalysis(object):
 
         freq = freq_GHz * 1e9  # freq in Hz
         for port_nm, port in self.pinfo.ports.items():
-            I_peak = self.calc_avg_current_J_surf_mag(variation, port['rect'],
-                                                      port['line'])
-            U_dissip = 0.5 * port['R'] * I_peak**2 * 1 / freq
+            if self.pinfo.options.method_calc_Q == 'Jsurf':
+                I_peak = self.calc_avg_current_J_surf_mag(variation, 
+                                                          port['rect'],
+                                                          port['line'])
+                P = 0.5 * port['R'] * I_peak**2
+            elif self.pinfo.options.method_calc_Q == 'SurfaceLossDensity':
+                P = self.calc_surf_loss(variation, port['rect'])
+            else:
+                raise NotImplementedError('Other calculation methods \
+                                          (self.pinfo.options.method_calc_Q) \
+                                          are possible but not implemented here.')
+            U_dissip = P / freq
             p = U_dissip / (U_E/2)  # U_E is 2x the peak electrical energy
             kappa = p * freq
             Q = 2 * np.pi * freq / kappa

--- a/pyEPR/core_quantum_analysis.py
+++ b/pyEPR/core_quantum_analysis.py
@@ -265,7 +265,7 @@ class QuantumAnalysis(object):
         self.convergence = results['convergence']
         self.convergence_f_pass = results['convergence_f_pass']
 
-        self.n_modes = len(self.modes['0'])
+        self.n_modes = len(self.modes[self.variations[0]])
         self._renorm_pj = config.epr.renorm_pj
 
         # Unique variation params -- make a get function

--- a/pyEPR/project_info.py
+++ b/pyEPR/project_info.py
@@ -263,8 +263,12 @@ class ProjectInfo(object):
                 elif self.design.solution_type == 'DrivenModal':
                     setup = self.design.create_dm_setup()  # adding a driven modal design
                     self.setup_name = setup.name
-            else:
+            elif self.setup_name == None:
                 self.setup_name = setup_names[0]
+            elif self.setup_name not in setup_names:
+                logger.error(f"\tSetup does not exist.")
+                raise(Exception(' Did you provide the correct setup name?\
+                    Failed to pull up setup. \N{loudly crying face}'))
 
             # get the actual setup if there is one
             self.get_setup(self.setup_name)

--- a/pyEPR/project_info.py
+++ b/pyEPR/project_info.py
@@ -189,6 +189,7 @@ class ProjectInfo(object):
         # TODO: introduce modal labels
         self.junctions = Dict()  # See above for help
         self.ports = Dict()
+        self.resonators = Dict()
 
         # Dissipative HFSS volumes and surfaces
         self.dissipative = self._Dissipative()


### PR DESCRIPTION
- bug fixes

- new method to calculate the dissipated power in a resistor using the Poynting vector (reproduces very precisely the Qs determined by HFSS unlike the method calculating the average current in the resistor)

- do not necessarily integrate |E|^2 and |H|^2 to determine the total mode energy. Default method integrates |E|^2 only because it is way much faster to integrate |E|^2 than |H|^2 (don't know why). Furthermore HFSS claims it fixes the total mode energy to 1 Joule, but it is true only for a VERY WELL converged solution.