### PR TITLE
Replace attrdict with metadict

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,11 +148,11 @@ Please keep up to date with `pyEPR` by using git. We like to make it simple usin
       $ echo %PATH%
       `
 
- 2. Install the required packages, including [pint](http://pint.readthedocs.io/en/latest/), [qutip](http://qutip.org/), and [attrdict](https://github.com/bcj/AttrDict). In a terminal window
+ 2. Install the required packages, including [pint](http://pint.readthedocs.io/en/latest/), [qutip](http://qutip.org/), and [metadict](https://github.com/LarsHill/metadict/). In a terminal window
  ```sh
  conda install -c conda-forge pint
  conda install -c conda-forge qutip
- pip install attrdict
+ pip install metadict
  ```
  3. Fork this pyEPR repository on GitHub with your GitHub account. You may clone the fork to your PC and manage it using the [SourceTree](https://www.sourcetreeapp.com/) git-gui manager.
  4. Add the pyEPR repository folder to your python search path. Make sure to add the git remote to the master is set up,  `git remote add MASTER_MINEV git://github.com/zlatko-minev/pyEPR.git`!  [(Help?)](https://stackoverflow.com/questions/11266478/git-add-remote-branch)

--- a/pyEPR/__init__.py
+++ b/pyEPR/__init__.py
@@ -76,12 +76,12 @@ import warnings
 from pathlib import Path
 
 try:
-    from attrdict import AttrDict as Dict
+    from metadict import MetaDict as Dict
 except (ImportError, ModuleNotFoundError):
-    raise ImportError("""Please install python package `AttrDict`.
-    AttrDict is in PyPI, so it can be installed directly
-    (https://github.com/bcj/AttrDict) using:
-        $ pip install attrdict""")
+    raise ImportError("""Please install python package `MetaDict`.
+    MetaDict is in PyPI, so it can be installed directly
+    (https://github.com/LarsHill/metadict/) using:
+        $ pip install metadict""")
 
 ##############################################################################
 # Python header

--- a/recepies/junk/meta2.yaml
+++ b/recepies/junk/meta2.yaml
@@ -19,7 +19,7 @@ requirements:
     - pip
     - setuptools
     - numpy >=1.15
-    - attrdict
+    - metadict
 
 test:
   imports:

--- a/recepies/meta.yaml
+++ b/recepies/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - qutip
     - ipython>=7.0.0
     - seaborn>=0.10.0
-    - attrdict
+    - metadict
 test:
   imports:
     - pyEPR

--- a/recepies/meta_zlatko.yaml
+++ b/recepies/meta_zlatko.yaml
@@ -45,11 +45,11 @@ requirements:
     # - qutip
     - ipython>=7.0.0
     - seaborn>=0.10.0
-    # - attrdict
+    # - metadict
     # - pip:
       # works for regular pip packages
-      # - attrdict
-    # WARNING: attrdict, pint, and qutip failed conda 
+      # - metadict
+    # WARNING: metadict, pint, and qutip failed conda
 
 # test:
   # imports:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-attrdict>=1.8.0
+metadict>=0.1.2
 numpy>=1.15.0
 pandas>=1.0.1
 matplotlib>=3.1.0

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,6 @@ setup(name='pyEPR',
         "Environment :: Console",
         "License :: OSI Approved :: Apache Software License"],
       python_requires=">=3.5, <4",
-      # install_requires=['numpy','pandas','pint','matplotlib','attrdict','sympy','IPython'],
+      # install_requires=['numpy','pandas','pint','matplotlib','metadict','sympy','IPython'],
       install_requires=requirements
       )


### PR DESCRIPTION
# What?

pyEPR uses a package called `AttrDict`. `AttrDict` is not compatible with python 3.9 and above, so one has to use an old version of python to work with pyEPR. This change aims at fixing this by replacing `AttrDict` with another package that is compatible with later versions of python.

We replace `AttrDict` (https://pypi.org/project/attrdict/) with `MetaDict` (https://pypi.org/project/metadict/0.1.2/). Both packages expose dictionary-like objects so the change will be totally transparent to the user.

# How?

[In the code](https://github.com/QuanticParis/pyEPR/pull/4/files#diff-107793ce5afe959ecb67a5d0c426dd5cd07aca237ee9bbd8a7d8c4597b2ccb41R79), we have 
```
from attrdict import AttrDict as Dict

# everywhere else:
from . import Dict
```
we just had to replace it with
```
from metadict import MetaDict as Dict
```

# Does it work?

Yes, it works with the demo script from pyEPR, tested on Windows with python 3.7. Feel free to test it on your own machine before approving